### PR TITLE
입력 페이지 수정 및 보강

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "chatscope"
+    ]
+}

--- a/src/chat/Avatar/Avatar.d.ts
+++ b/src/chat/Avatar/Avatar.d.ts
@@ -1,0 +1,14 @@
+import type {Size, UserStatus, ChatComponentPropsChildrenRef} from "../../types";
+import type {ReactElement} from "react";
+
+export interface AvatarProps {
+    name?:string;
+    src?:string;
+    size?: Size;
+    status?: UserStatus;
+    active?: boolean;
+}
+
+export declare const Avatar: (props:ChatComponentPropsChildrenRef<AvatarProps,"div">) => ReactElement;
+
+export default Avatar;

--- a/src/chat/Avatar/Avatar.jsx
+++ b/src/chat/Avatar/Avatar.jsx
@@ -1,0 +1,66 @@
+import React, { useRef, forwardRef, useImperativeHandle } from "react";
+import PropTypes from "prop-types";
+import { prefix } from "../settings";
+import classNames from "classnames";
+import { SizeEnum, StatusEnum } from "../enums";
+
+function AvatarInner(
+  { name = "", src = "", size = "md", status, className, active = false, children, ...rest },
+  ref
+) {
+  const cName = `${prefix}-avatar`;
+  const sizeClass = typeof size !== "undefined" ? ` ${cName}--${size}` : "";
+
+  const avatarRef = useRef();
+
+  useImperativeHandle(ref, () => ({
+    focus: () => avatarRef.current.focus(),
+  }));
+
+  return (
+    <div
+      ref={avatarRef}
+      {...rest}
+      className={classNames(
+        `${cName}${sizeClass}`,
+        { [`${cName}--active`]: active },
+        className
+      )}
+    >
+
+    </div>
+  );
+}
+
+const Avatar = forwardRef(AvatarInner);
+Avatar.displayName = "Avatar";
+
+Avatar.propTypes = {
+  /** Primary content */
+  children: PropTypes.node,
+
+  /**
+   * User name/nickname/full name for displaying initials and image alt description
+   */
+  name: PropTypes.string,
+
+  /** Avatar image source */
+  src: PropTypes.string,
+
+  /** Size */
+  size: PropTypes.oneOf(SizeEnum),
+
+  /** Status. */
+  status: PropTypes.oneOf(StatusEnum),
+
+  /** Active */
+  active: PropTypes.bool,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+AvatarInner.propTypes = Avatar.propTypes;
+
+export { Avatar };
+export default Avatar;

--- a/src/chat/Avatar/index.js
+++ b/src/chat/Avatar/index.js
@@ -1,0 +1,3 @@
+import Avatar from "./Avatar";
+export * from "./Avatar";
+export default Avatar;

--- a/src/chat/Chatuikit.stories.tsx
+++ b/src/chat/Chatuikit.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Chatuikit } from './Chatuikit';
+
+const meta: Meta<typeof Chatuikit> = {
+  title: 'Chat/Chatuikit',
+  component: Chatuikit,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/chat/Chatuikit.tsx
+++ b/src/chat/Chatuikit.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { MainContainer, ChatContainer, MessageList, MessageInput, Conversation, ConversationList, Avatar, Sidebar, ConversationHeader, ExpansionPanel, InfoButton, MessageSeparator, Message, Search } from '@chatscope/chat-ui-kit-react';
-import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css'; // 스타일 파일을 불러오는 방식으로 수정
+import { MainContainer, ChatContainer, MessageList, MessageInput, Conversation, ConversationList, Avatar, Sidebar, ConversationHeader, ExpansionPanel, InfoButton, MessageSeparator, Search } from '@chatscope/chat-ui-kit-react';
+import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
+import Message from './Message'
 
 export const Chatuikit: React.FC = () => {
     return (
@@ -130,7 +131,6 @@ export const Chatuikit: React.FC = () => {
                 />
               </Message>
               <Message
-                avatarSpacer
                 model={{
                   direction: 'outgoing',
                   message: 'Hello my friend',
@@ -170,6 +170,7 @@ export const Chatuikit: React.FC = () => {
                 }}
               />
               <Message
+                avatarSpacer
                 model={{
                   direction: 'incoming',
                   message: 'Hello my friend',
@@ -230,6 +231,7 @@ export const Chatuikit: React.FC = () => {
                 }}
               />
               <Message
+              avatarSpacer
                 model={{
                   direction: 'incoming',
                   message: 'Hello my friend',
@@ -246,81 +248,6 @@ export const Chatuikit: React.FC = () => {
             </MessageList>
             <MessageInput placeholder="Type message here" />
           </ChatContainer>
-          <Sidebar position="right">
-            <ExpansionPanel
-              open
-              title="INFO"
-            >
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-            </ExpansionPanel>
-            <ExpansionPanel title="LOCALIZATION">
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-            </ExpansionPanel>
-            <ExpansionPanel title="MEDIA">
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-            </ExpansionPanel>
-            <ExpansionPanel title="SURVEY">
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-            </ExpansionPanel>
-            <ExpansionPanel title="OPTIONS">
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-              <p>
-                Lorem ipsum
-              </p>
-            </ExpansionPanel>
-          </Sidebar>
         </MainContainer>
     );
 };

--- a/src/chat/Chatuikit.tsx
+++ b/src/chat/Chatuikit.tsx
@@ -1,0 +1,326 @@
+import React from 'react';
+import { MainContainer, ChatContainer, MessageList, MessageInput, Conversation, ConversationList, Avatar, Sidebar, ConversationHeader, ExpansionPanel, InfoButton, MessageSeparator, Message, Search } from '@chatscope/chat-ui-kit-react';
+import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css'; // 스타일 파일을 불러오는 방식으로 수정
+
+export const Chatuikit: React.FC = () => {
+    return (
+        <MainContainer
+          responsive
+          style={{
+            height: '600px'
+          }}
+        >
+          <Sidebar
+            position="left"
+          >
+            <Search placeholder="Search..." />
+            <ConversationList>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Lilly"
+                name="Lilly"
+              >
+                <Avatar
+                  name="Lilly"
+                  src="https://chatscope.io/storybook/react/assets/lilly-aj6lnGPk.svg"
+                />
+              </Conversation>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Joe"
+                name="Joe"
+              >
+                <Avatar
+                  name="Joe"
+                  src="https://chatscope.io/storybook/react/assets/joe-v8Vy3KOS.svg"
+                />
+              </Conversation>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Emily"
+                name="Emily"
+                unreadCnt={3}
+              >
+                <Avatar
+                  name="Emily"
+                  src="https://chatscope.io/storybook/react/assets/emily-xzL8sDL2.svg"
+                />
+              </Conversation>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Kai"
+                name="Kai"
+              >
+                <Avatar
+                  name="Kai"
+                  src="https://chatscope.io/storybook/react/assets/kai-5wHRJGb2.svg"
+                />
+              </Conversation>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Akane"
+                name="Akane"
+              >
+                <Avatar
+                  name="Akane"
+                  src="https://chatscope.io/storybook/react/assets/akane-MXhWvx63.svg"
+                />
+              </Conversation>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Eliot"
+                name="Eliot"
+              >
+                <Avatar
+                  name="Eliot"
+                  src="https://chatscope.io/storybook/react/assets/eliot-JNkqSAth.svg"
+                />
+              </Conversation>
+              <Conversation
+                active
+                info="Yes i can do it for you"
+                lastSenderName="Zoe"
+                name="Zoe"
+              >
+                <Avatar
+                  name="Zoe"
+                  src="https://chatscope.io/storybook/react/assets/zoe-E7ZdmXF0.svg"
+                />
+              </Conversation>
+              <Conversation
+                info="Yes i can do it for you"
+                lastSenderName="Patrik"
+                name="Patrik"
+              >
+                <Avatar
+                  name="Patrik"
+                  src="https://chatscope.io/storybook/react/assets/patrik-yC7svbAR.svg"
+                />
+              </Conversation>
+            </ConversationList>
+          </Sidebar>
+          <ChatContainer>
+            <ConversationHeader>
+              <ConversationHeader.Back />
+              <Avatar
+                name="Zoe"
+                src="https://chatscope.io/storybook/react/assets/zoe-E7ZdmXF0.svg"
+              />
+              <ConversationHeader.Content
+                userName="Zoe"
+              />
+              <ConversationHeader.Actions>
+                <InfoButton />
+              </ConversationHeader.Actions>
+            </ConversationHeader>
+            <MessageList>
+              <MessageSeparator content="Saturday, 30 November 2019" />
+              <Message
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'single',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              >
+                <Avatar
+                  name="Zoe"
+                  src="https://chatscope.io/storybook/react/assets/zoe-E7ZdmXF0.svg"
+                />
+              </Message>
+              <Message
+                avatarSpacer
+                model={{
+                  direction: 'outgoing',
+                  message: 'Hello my friend',
+                  position: 'single',
+                  sender: 'Patrik',
+                  sentTime: '15 mins ago'
+                }}
+              />
+              <Message
+                avatarSpacer
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'first',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              />
+              <Message
+                avatarSpacer
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'normal',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              />
+              <Message
+                avatarSpacer
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'normal',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              />
+              <Message
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'last',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              >
+                <Avatar
+                  name="Zoe"
+                  src="https://chatscope.io/storybook/react/assets/zoe-E7ZdmXF0.svg"
+                />
+              </Message>
+              <Message
+                model={{
+                  direction: 'outgoing',
+                  message: 'Hello my friend',
+                  position: 'first',
+                  sender: 'Patrik',
+                  sentTime: '15 mins ago'
+                }}
+               />
+              <Message
+                model={{
+                  direction: 'outgoing',
+                  message: 'Hello my friend',
+                  position: 'normal',
+                  sender: 'Patrik',
+                  sentTime: '15 mins ago'
+                }}
+               />
+              <Message
+                model={{
+                  direction: 'outgoing',
+                  message: 'Hello my friend',
+                  position: 'normal',
+                  sender: 'Patrik',
+                  sentTime: '15 mins ago'
+                }}
+               />
+              <Message
+                model={{
+                  direction: 'outgoing',
+                  message: 'Hello my friend',
+                  position: 'last',
+                  sender: 'Patrik',
+                  sentTime: '15 mins ago'
+                }}
+               />
+              <Message
+                avatarSpacer
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'first',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              />
+              <Message
+                model={{
+                  direction: 'incoming',
+                  message: 'Hello my friend',
+                  position: 'last',
+                  sender: 'Zoe',
+                  sentTime: '15 mins ago'
+                }}
+              >
+                <Avatar
+                  name="Zoe"
+                  src="https://chatscope.io/storybook/react/assets/zoe-E7ZdmXF0.svg"
+                />
+              </Message>
+            </MessageList>
+            <MessageInput placeholder="Type message here" />
+          </ChatContainer>
+          <Sidebar position="right">
+            <ExpansionPanel
+              open
+              title="INFO"
+            >
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+            </ExpansionPanel>
+            <ExpansionPanel title="LOCALIZATION">
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+            </ExpansionPanel>
+            <ExpansionPanel title="MEDIA">
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+            </ExpansionPanel>
+            <ExpansionPanel title="SURVEY">
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+            </ExpansionPanel>
+            <ExpansionPanel title="OPTIONS">
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+              <p>
+                Lorem ipsum
+              </p>
+            </ExpansionPanel>
+          </Sidebar>
+        </MainContainer>
+    );
+};

--- a/src/chat/CustomMessage.tsx
+++ b/src/chat/CustomMessage.tsx
@@ -1,0 +1,47 @@
+import React, { ReactNode } from 'react';
+import { Message } from '@chatscope/chat-ui-kit-react';
+
+interface CustomMessageProps {
+  avatarSpacer?: boolean;
+  unreadCount: number;
+  model: {
+    direction: 'incoming' | 'outgoing';
+    message: string;
+    position: 'normal' | 'single' | 'first' | 'last';
+    sender?: string;
+    sentTime?: string;
+  };
+  children?: ReactNode;
+}
+
+const CustomMessage: React.FC<CustomMessageProps> = ({ avatarSpacer, unreadCount, model, children }) => {
+  const isIncoming = model.direction === 'incoming';
+
+  return (
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
+
+      {unreadCount > 0 && (
+        <span
+          style={{
+            position: 'absolute',
+            fontSize: '0.75rem',
+            color: '#fff',
+            backgroundColor: '#f44336',
+            borderRadius: '50%',
+            padding: '2px 6px',
+            top: '-5px',
+            [isIncoming ? 'right' : 'left']: '-10px',
+          }}
+        >
+          {unreadCount}
+        </span>
+      )}
+
+      <Message avatarSpacer={avatarSpacer} model={model} />
+      
+      {children}
+    </div>
+  );
+};
+
+export default CustomMessage;

--- a/src/chat/Message/Message.d.ts
+++ b/src/chat/Message/Message.d.ts
@@ -1,0 +1,83 @@
+import type {ReactElement, ReactNode} from "react";
+import type {ChatComponentPropsChildren, ChatComponentProps, EmptyProps, MessageType} from "../../types";
+import type {AvatarPosition, MessageDirection} from "../../types/unions";
+
+export type MessageCustomContentProps = EmptyProps;
+
+declare const MessageCustomContent: (props:ChatComponentPropsChildren<MessageCustomContentProps, "div">) => ReactElement;
+
+export interface MessageHtmlContentProps {
+    html?:string;
+}
+
+declare const MessageHtmlContent: (props:ChatComponentProps<MessageHtmlContentProps, "div">) => ReactElement;
+
+export interface MessageImageContentProps {
+    src?:string;
+    width?:string|number;
+    height?:string|number;
+    alt?:string;
+}
+
+declare const MessageImageContent: (props:ChatComponentProps<MessageImageContentProps, "div">) => ReactElement;
+
+export interface MessageTextContentProps {
+    text?:string;
+}
+
+declare const MessageTextContent: (props:ChatComponentPropsChildren<MessageTextContentProps, "div">) => ReactElement;
+
+export interface MessageHeaderProps {
+    sender?:string;
+    sentTime?:string;
+}
+
+declare const MessageHeader: (props:ChatComponentPropsChildren<MessageHeaderProps, "div">) => ReactElement;
+
+export interface MessageFooterProps {
+    sender?:string;
+    sentTime?:string;
+}
+
+declare const MessageFooter: (props:ChatComponentPropsChildren<MessageFooterProps, "div">) => ReactElement;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type MessagePayload = string | Record<string, any> | MessageImageContentProps | ReactNode;
+    
+export interface MessageModel {
+    message?:string;
+    sentTime?:string;
+    sender?:string;
+    direction: MessageDirection;
+    position: "single" | "first" | "normal" | "last" | 0 |  1 | 2 | 3;
+    type?: MessageType;
+    payload?: MessagePayload;
+}
+
+export interface MessageProps {
+    model?: MessageModel;
+    avatarSpacer?:boolean;
+    avatarPosition?: AvatarPosition;
+    type?: MessageType;
+    payload?: MessagePayload;
+}
+
+declare const Message: {
+    (props:ChatComponentPropsChildren<MessageProps, HTMLElement>):ReactElement;
+    Header: typeof MessageHeader;
+    HtmlContent: typeof MessageHtmlContent;
+    TextContent: typeof MessageTextContent;
+    ImageContent: typeof MessageImageContent;
+    CustomContent: typeof MessageCustomContent;
+    Footer:typeof MessageFooter;
+};
+
+export {
+    MessageCustomContent,
+    MessageHtmlContent,
+    MessageImageContent,
+    MessageTextContent,
+    Message
+};
+
+export default Message;

--- a/src/chat/Message/Message.jsx
+++ b/src/chat/Message/Message.jsx
@@ -1,0 +1,217 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { allowedChildren, getChildren, getComponentName } from "../utils";
+import { prefix } from "../settings";
+import Avatar from "../Avatar";
+import MessageHeader from "./MessageHeader";
+import MessageFooter from "./MessageFooter";
+import MessageCustomContent from "./MessageCustomContent";
+import MessageImageContent from "./MessageImageContent";
+import MessageHtmlContent from "./MessageHtmlContent";
+import MessageTextContent from "./MessageTextContent";
+
+export const Message = ({
+  model: {
+    message = "",
+    sentTime = "",
+    sender = "",
+    direction = 1,
+    position,
+    type: modelType,
+    payload: modelPayload,
+  },
+  avatarSpacer = false,
+  avatarPosition = undefined,
+  type = "html",
+  payload: argPayload,
+  unreadCount = 1, // 추가된 unreadCount prop
+  children,
+  className,
+  ...rest
+}) => {
+  const cName = `${prefix}-message`;
+
+  const [
+    avatar,
+    header,
+    footer,
+    htmlContent,
+    textContent,
+    imageContent,
+    customContent,
+  ] = getChildren(children, [
+    Avatar,
+    MessageHeader,
+    MessageFooter,
+    MessageHtmlContent,
+    MessageTextContent,
+    MessageImageContent,
+    MessageCustomContent,
+  ]);
+
+  const directionClass = (() => {
+    if (direction === 0 || direction === "incoming") {
+      return `${cName}--incoming`;
+    } else if (direction === 1 || direction === "outgoing") {
+      return `${cName}--outgoing`;
+    }
+  })();
+
+  const avatarPositionClass = ((position) => {
+    const classPrefix = `${cName}--avatar-`;
+    if (position === 0 || position === "top-left" || position === "tl") {
+      return `${classPrefix}tl`;
+    } else if (
+      position === 1 ||
+      position === "top-right" ||
+      position === "tr"
+    ) {
+      return `${classPrefix}tr`;
+    } else if (
+      position === 2 ||
+      position === "bottom-right" ||
+      position === "br"
+    ) {
+      return `${classPrefix}br`;
+    } else if (
+      position === 3 ||
+      position === "bottom-left" ||
+      position === "bl"
+    ) {
+      return `${classPrefix}bl`;
+    } else if (
+      position === 4 ||
+      position === "center-left" ||
+      position === "cl"
+    ) {
+      return `${classPrefix}cl`;
+    } else if (
+      position === 5 ||
+      position === "center-right" ||
+      position === "cr"
+    ) {
+      return `${classPrefix}cr`;
+    }
+  })(avatarPosition);
+
+  const positionClass = ((position) => {
+    const classPrefix = `${prefix}-message--`;
+    if (position === "single" || position === 0) {
+      return `${classPrefix}single`;
+    } else if (position === "first" || position === 1) {
+      return `${classPrefix}first`;
+    } else if (position === "normal" || position === 2) {
+      return "";
+    } else if (position === "last" || position === 3) {
+      return `${classPrefix}last`;
+    }
+  })(position);
+
+  const ariaLabel = (() => {
+    if (sender?.length > 0 && sentTime?.length > 0) {
+      return `${sender}: ${sentTime}`;
+    } else if (
+      sender?.length > 0 &&
+      (typeof sentTime === "undefined" || sentTime?.length === 0)
+    ) {
+      return sender;
+    } else {
+      return null;
+    }
+  })();
+
+  const childContent =
+    htmlContent ?? textContent ?? imageContent ?? customContent;
+
+  const messageContent =
+    childContent ??
+    (() => {
+      const messageType = modelType ?? type;
+      const payloadFromModel = modelPayload ?? message;
+      const payload = payloadFromModel ?? argPayload;
+
+      const payloadName =
+        typeof payload === "object" ? getComponentName(payload) : "";
+
+      if (messageType === "html" && payloadName !== "Message.CustomContent") {
+        return <MessageHtmlContent html={payload} />;
+      } else if (messageType === "text") {
+        return <MessageTextContent text={payload} />;
+      } else if (messageType === "image") {
+        return <MessageImageContent {...payload} />;
+      } else if (
+        messageType === "custom" ||
+        payloadName === "Message.CustomContent"
+      ) {
+        return payload;
+      }
+    })();
+
+  return (
+    <section
+      {...rest}
+      aria-label={ariaLabel}
+      className={classNames(
+        cName,
+        directionClass,
+        { [`${cName}--avatar-spacer`]: avatarSpacer },
+        positionClass,
+        avatarPositionClass,
+        className
+      )}
+      {...{ [`data-${prefix}-message`]: "" }}
+    >
+      {typeof avatar !== "undefined" && (
+        <div className={`${cName}__avatar`}>{avatar}</div>
+      )}
+      <div className={`${cName}__content-wrapper`} style={{ position: "relative", display: "flex" }}>
+        {header}
+        <div className={`${cName}__content`}>{messageContent}</div>
+        {/* unreadCount 표시 */}
+        {unreadCount > 0 && (
+            <span
+            style={{
+              position: 'absolute',
+              top: '5px', 
+              [direction === 'incoming' ? 'right' : 'left']: '-10px', 
+              color: '#000', 
+              fontSize: '0.6rem', 
+              fontWeight: 'bold',
+            }}
+          >
+            {unreadCount}
+          </span>
+        )}
+        {footer}
+      </div>
+    </section>
+  );
+};
+
+Message.propTypes = {
+  model: PropTypes.shape({
+    message: PropTypes.string,
+    sentTime: PropTypes.string,
+    sender: PropTypes.string,
+    direction: PropTypes.oneOf(["incoming", "outgoing", 0, 1]),
+    position: PropTypes.oneOf(["single", "first", "normal", "last", 0, 1, 2, 3]),
+    type: PropTypes.oneOf(["html", "text", "image", "custom"]),
+    payload: PropTypes.oneOfType([PropTypes.string, PropTypes.object, allowedChildren([MessageCustomContent])]),
+  }),
+  avatarSpacer: PropTypes.bool,
+  avatarPosition: PropTypes.oneOf(["tl", "tr", "cl", "cr", "bl", "br", "top-left", "top-right", "center-left", "center-right", "bottom-left", "bottom-right"]),
+  className: PropTypes.string,
+  type: PropTypes.oneOf(["html", "text", "image", "custom"]),
+  payload: PropTypes.oneOfType([PropTypes.string, allowedChildren([MessageCustomContent])]),
+  unreadCount: PropTypes.number,
+};
+
+Message.Header = MessageHeader;
+Message.HtmlContent = MessageHtmlContent;
+Message.TextContent = MessageTextContent;
+Message.ImageContent = MessageImageContent;
+Message.CustomContent = MessageCustomContent;
+Message.Footer = MessageFooter;
+
+export default Message;

--- a/src/chat/Message/MessageCustomContent.jsx
+++ b/src/chat/Message/MessageCustomContent.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { prefix } from "../settings";
+
+export const MessageCustomContent = ({ children, className }) => {
+  const cName = `${prefix}-message__custom-content`;
+
+  return <div className={classNames(cName, className)}>{children}</div>;
+};
+
+MessageCustomContent.displayName = "Message.CustomContent";
+
+MessageCustomContent.propTypes = {
+  /** Primary content. */
+  children: PropTypes.node,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+export default MessageCustomContent;

--- a/src/chat/Message/MessageFooter.jsx
+++ b/src/chat/Message/MessageFooter.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+
+import { prefix } from "../settings";
+
+export const MessageFooter = ({
+  sender = "",
+  sentTime = "",
+  children = undefined,
+  className,
+  ...rest
+}) => {
+  const cName = `${prefix}-message__footer`;
+
+  return (
+    <div {...rest} className={classNames(cName, className)}>
+      {typeof children !== "undefined" ? (
+        children
+      ) : (
+        <>
+          <div className={`${prefix}-message__sender-name`}>{sender}</div>
+          <div className={`${prefix}-message__sent-time`}>{sentTime}</div>
+        </>
+      )}
+    </div>
+  );
+};
+
+MessageFooter.displayName = "Message.Footer";
+
+MessageFooter.propTypes = {
+  sender: PropTypes.string,
+  sentTime: PropTypes.string,
+
+  /** Primary content. */
+  children: PropTypes.node,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+export default MessageFooter;

--- a/src/chat/Message/MessageHeader.jsx
+++ b/src/chat/Message/MessageHeader.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { prefix } from "../settings";
+
+export const MessageHeader = ({
+  sender = "",
+  sentTime = "",
+  children = undefined,
+  className,
+  ...rest
+}) => {
+  const cName = `${prefix}-message__header`;
+
+  return (
+    <div {...rest} className={classNames(cName, className)}>
+      {typeof children !== "undefined" ? (
+        children
+      ) : (
+        <>
+          <div className={`${prefix}-message__sender-name`}>{sender}</div>
+          <div className={`${prefix}-message__sent-time`}>{sentTime}</div>
+        </>
+      )}
+    </div>
+  );
+};
+
+MessageHeader.displayName = "Message.Header";
+
+MessageHeader.propTypes = {
+  sender: PropTypes.string,
+  sentTime: PropTypes.string,
+
+  /** Primary content. */
+  children: PropTypes.node,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+export default MessageHeader;

--- a/src/chat/Message/MessageHtmlContent.jsx
+++ b/src/chat/Message/MessageHtmlContent.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { prefix } from "../settings";
+
+export const MessageHtmlContent = ({ html, className }) => {
+  const cName = `${prefix}-message__html-content`;
+
+  const createMarkup = () => ({ __html: html });
+
+  return (
+    <div
+      className={classNames(cName, className)}
+      dangerouslySetInnerHTML={createMarkup()}
+    />
+  );
+};
+
+MessageHtmlContent.displayName = "Message.HtmlContent";
+
+MessageHtmlContent.propTypes = {
+  /**
+   * Html string will be rendered in component using dangerouslySetInnerHTML
+   */
+  html: PropTypes.string,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+export default MessageHtmlContent;

--- a/src/chat/Message/MessageImageContent.jsx
+++ b/src/chat/Message/MessageImageContent.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { prefix } from "../settings";
+
+export const MessageImageContent = ({ src, width, height, alt, className }) => {
+  const cName = `${prefix}-message__image-content`;
+
+  const style = {
+    width:
+      typeof width === "number"
+        ? `${width}px`
+        : typeof width === "string"
+        ? width
+        : undefined,
+    height:
+      typeof height === "number"
+        ? `${height}px`
+        : typeof height === "string"
+        ? height
+        : undefined,
+  };
+
+  return (
+    <div className={classNames(cName, className)}>
+      <img src={src} style={style} alt={alt} />
+    </div>
+  );
+};
+
+MessageImageContent.displayName = "Message.ImageContent";
+
+MessageImageContent.propTypes = {
+  /** Image source*/
+  src: PropTypes.string,
+
+  /** Image width */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /** Image height */
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /** Alternate text for image */
+  alt: PropTypes.string,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+export default MessageImageContent;

--- a/src/chat/Message/MessageTextContent.jsx
+++ b/src/chat/Message/MessageTextContent.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { prefix } from "../settings";
+
+export const MessageTextContent = ({ text, className, children }) => {
+  const cName = `${prefix}-message__text-content`;
+
+  const content = children ?? text;
+
+  return <div className={classNames(cName, className)}>{content}</div>;
+};
+
+MessageTextContent.displayName = "Message.TextContent";
+
+MessageTextContent.propTypes = {
+  /** Primary content - message text */
+  children: PropTypes.string,
+
+  /** Message text. Property has precedence over children */
+  text: PropTypes.string,
+
+  /** Additional classes. */
+  className: PropTypes.string,
+};
+
+export default MessageTextContent;

--- a/src/chat/Message/index.js
+++ b/src/chat/Message/index.js
@@ -1,0 +1,3 @@
+import Message from "./Message";
+export * from "./Message";
+export default Message;

--- a/src/chat/enums.js
+++ b/src/chat/enums.js
@@ -1,0 +1,18 @@
+export const StatusEnum = [
+  "available",
+  "unavailable",
+  "away",
+  "dnd",
+  "invisible",
+  "eager",
+];
+
+export const SizeEnum = ["xs", "sm", "md", "lg", "fluid"];
+
+export const MessageTypeEnum = ["html", "text", "image", "custom"];
+
+export default {
+  SizeEnum,
+  StatusEnum,
+  MessageTypeEnum,
+};

--- a/src/chat/index.js
+++ b/src/chat/index.js
@@ -1,0 +1,37 @@
+export { default as Avatar } from "./Avatar";
+export { default as AvatarGroup } from "./AvatarGroup";
+export { default as ChatContainer } from "./ChatContainer";
+export { default as Conversation } from "./Conversation";
+export { default as ConversationHeader } from "./ConversationHeader";
+export { default as ConversationList } from "./ConversationList";
+export { default as ExpansionPanel } from "./ExpansionPanel";
+export { default as InputToolbox } from "./InputToolbox";
+export { default as MainContainer } from "./MainContainer";
+export { default as Message } from "./Message";
+export { default as MessageGroup } from "./MessageGroup";
+export { default as MessageInput } from "./MessageInput";
+export { default as MessageList } from "./MessageList";
+export { default as MessageSeparator } from "./MessageSeparator";
+export { default as Search } from "./Search";
+export { default as Sidebar } from "./Sidebar";
+export { default as Status } from "./Status";
+export { default as TypingIndicator } from "./TypingIndicator";
+export { default as Loader } from "./Loader";
+export { default as Overlay } from "./Overlay";
+export { default as StatusList } from "./StatusList";
+
+// Buttons
+export { default as Buttons } from "./Buttons";
+export { default as Button } from "./Buttons/Button";
+export { default as ArrowButton } from "./Buttons/ArrowButton";
+export { default as InfoButton } from "./Buttons/InfoButton";
+export { default as VoiceCallButton } from "./Buttons/VoiceCallButton";
+export { default as VideoCallButton } from "./Buttons/VideoCallButton";
+export { default as StarButton } from "./Buttons/StarButton";
+export { default as AddUserButton } from "./Buttons/AddUserButton";
+export { default as EllipsisButton } from "./Buttons/EllipsisButton";
+export { default as SendButton } from "./Buttons/SendButton";
+export { default as AttachmentButton } from "./Buttons/AttachmentButton";
+
+// Enums
+export { default as Enums } from "./enums";

--- a/src/chat/settings.js
+++ b/src/chat/settings.js
@@ -1,0 +1,3 @@
+const prefix = "cs";
+
+export { prefix };

--- a/src/chat/utils.js
+++ b/src/chat/utils.js
@@ -1,0 +1,144 @@
+import React from "react";
+
+/* eslint-disable  @typescript-eslint/no-empty-function */
+export const noop = () => {};
+
+/**
+ * Tests if children are nil in React and Preact.
+ * @param {Object} children The children prop of a component.
+ * @returns {Boolean}
+ */
+export const isChildrenNil = (children) =>
+  children === null ||
+  children === undefined ||
+  (Array.isArray(children) && children.length === 0);
+
+/**
+ * Gets only specified types children
+ * @param children
+ * @param {Array} types
+ * @returns {[]}
+ */
+export const getChildren = (children, types) => {
+  const ret = [];
+  const strTypes = types.map((t) => t.displayName || t.name);
+
+  React.Children.toArray(children).forEach((item) => {
+    const idx = types.indexOf(item.type);
+    if (idx !== -1) {
+      ret[idx] = item;
+    } else {
+      const is = item?.props?.as ?? item?.props?.is;
+      const typeofIs = typeof is;
+      if (typeofIs === "function") {
+        // Type
+        const fIdx = types.indexOf(is);
+        if (fIdx !== -1) {
+          ret[fIdx] = React.cloneElement(item, { ...item.props, as: null }); // Cloning to remove "as" attribute, which is not desirable
+        }
+      } else if (typeofIs === "object") {
+        // forward ref
+
+        const typeName = is.name || is.displayName;
+        const tIdx = strTypes.indexOf(typeName);
+        if (tIdx !== -1) {
+          ret[tIdx] = React.cloneElement(item, { ...item.props, as: null }); // Cloning to remove "as" attribute, which is not desirable
+        }
+      } else if (typeofIs === "string") {
+        const sIdx = strTypes.indexOf(is);
+        if (sIdx !== -1) {
+          ret[sIdx] = item;
+        }
+      }
+    }
+  });
+
+  return ret;
+};
+
+export const getComponentName = (component) => {
+  if (typeof component === "string") {
+    return component;
+  }
+
+  if ("type" in component) {
+    const componentType = typeof component.type;
+
+    if (componentType === "function" || componentType === "object") {
+      if ("displayName" in component.type) {
+        return component.type.displayName;
+      }
+
+      if ("name" in component.type) {
+        return component.type.name;
+      }
+    } else if (componentType === "string") {
+      return component.type;
+    }
+
+    return "undefined";
+  }
+
+  return "undefined";
+};
+
+/**
+ * PropTypes validator.
+ * Checks if all children is allowed by its types.
+ * Empty string nodes are always allowed for convenience.
+ * Returns function for propTypes
+ * @param {Array} allowedTypes
+ * @return {Function}
+ */
+export const allowedChildren = (allowedTypes) => (
+  props,
+  propName,
+  componentName
+) => {
+  const allowedTypesAsStrings = allowedTypes.map(
+    (t) => t.name || t.displayName
+  );
+
+  // Function as Child is not supported by React.Children... functions
+  // and can be antipattern: https://americanexpress.io/faccs-are-an-antipattern/
+  // But we don't check fd function is passed as children and its intentional
+  // Passing function as children has no effect in chat-ui-kit
+  const forbidden = React.Children.toArray(props[propName]).find((item) => {
+    if (typeof item === "string" && item.trim().length === 0) {
+      // Ignore string
+      return false;
+    }
+
+    if (allowedTypes.indexOf(item.type) === -1) {
+      const is = item?.props?.as || item?.props?.is;
+
+      const typeofIs = typeof is;
+
+      if (typeofIs === "function") {
+        // Type
+        return allowedTypes.indexOf(is) === -1;
+      } else if (typeofIs === "object") {
+        // Forward ref
+        const typeName = is.name || is.displayName;
+        return allowedTypesAsStrings.indexOf(typeName) === -1;
+      } else if (typeofIs === "string") {
+        return allowedTypesAsStrings.indexOf(is) === -1;
+      } else {
+        return true;
+      }
+    }
+
+    return undefined;
+  });
+
+  if (typeof forbidden !== "undefined") {
+    const typeName = getComponentName(forbidden);
+
+    const allowedNames = allowedTypes
+      .map((t) => t.name || t.displayName)
+      .join(", ");
+    const errMessage = `"${typeName}" is not a valid child for ${componentName}. Allowed types: ${allowedNames}`;
+
+    return new Error(errMessage);
+  }
+};

--- a/src/components/ReviewOfCorp.tsx
+++ b/src/components/ReviewOfCorp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Theme, Progress, Grid, Box, Card, Flex, Text, Inset, Strong } from '@radix-ui/themes';
+import { Theme, Progress, Box, Card, Flex, Text, Inset, Strong } from '@radix-ui/themes';
 import RequestCard, { RequestCardProps } from './RequestCard';
-import { StarIcon, LightningBoltIcon, FaceIcon } from '@radix-ui/react-icons'
+import { StarIcon } from '@radix-ui/react-icons'
 
 export interface ReviewOfCorpProps {
     request_card: RequestCardProps;
@@ -9,8 +9,6 @@ export interface ReviewOfCorpProps {
     prep_requirement: string;
     work_atmosphere: string;
     sense_of_achive: number;
-    work_intensity: number;
-    pay_satisfaction: number;
 }
 
 const ReviewOfCorp: React.FC<ReviewOfCorpProps> = ({
@@ -19,8 +17,6 @@ const ReviewOfCorp: React.FC<ReviewOfCorpProps> = ({
     prep_requirement,
     work_atmosphere,
     sense_of_achive,
-    work_intensity,
-    pay_satisfaction,
 }) => {
     return (
         <Theme>
@@ -47,27 +43,12 @@ const ReviewOfCorp: React.FC<ReviewOfCorpProps> = ({
                         <Text as="p" size="4" style={{ marginTop: '8px' }}>
                             <Strong>Work Atmosphere: </Strong>{work_atmosphere}
                         </Text>
-                        <Grid columns="3" gap="4" style={{ marginTop: '16px', width: '100%' }}>
-                            
-                            <Box>
-                                <Flex align="center" justify="center" direction="column" gap="2">
-                                    <StarIcon/>
-                                    <Progress value={sense_of_achive * 10} style={{ width: '100%' }} />
-                                </Flex>
-                            </Box>
-                            <Box>
-                                <Flex align="center" justify="center" direction="column" gap="2">
-                                    <LightningBoltIcon/>
-                                    <Progress value={work_intensity * 10} style={{ width: '100%' }} />
-                                </Flex>
-                            </Box>
-                            <Box>
-                                <Flex align="center" justify="center" direction="column" gap="2">
-                                    <FaceIcon/>
-                                    <Progress value={pay_satisfaction * 10} style={{ width: '100%' }} />
-                                </Flex>
-                            </Box>
-                        </Grid>
+                        <Box>
+                            <Flex align="center" justify="center" direction="column" gap="2">
+                                <StarIcon/>
+                                <Progress value={sense_of_achive * 10} style={{ width: '100%' }} />
+                            </Flex>
+                        </Box>
                     </Flex>
                 </Card>
             </Box>

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,0 +1,3 @@
+// src/declarations.d.ts
+
+declare module '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';

--- a/src/input/BasicInfoInput.tsx
+++ b/src/input/BasicInfoInput.tsx
@@ -14,6 +14,8 @@ const BasicInfoInput: React.FC<BasicInfoInputProps> = ({ control, onNext }) => {
       <ShortTextInput control={control} name="age" label="Age" />
       <ShortTextInput control={control} name="gender" label="Gender" />
       <ShortTextInput control={control} name="nationality" label="Nationality" />
+      <ShortTextInput control={control} name="phone nubmer" label="Phone Number" />
+      <ShortTextInput control={control} name="emergency contact" label="Emergency Contact" />
       <button type="button" onClick={onNext}>Next</button>
     </div>
   );

--- a/src/input/BusinessInfoVerification.tsx
+++ b/src/input/BusinessInfoVerification.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, Button, CircularProgress } from '@mui/material';
+
+interface BusinessInfoVerificationProps {
+  businessNumber: string;
+  onNext: () => void;
+}
+
+const BusinessInfoVerification: React.FC<BusinessInfoVerificationProps> = ({ businessNumber, onNext }) => {
+  const [businessInfo, setBusinessInfo] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // 비즈니스 정보 가져오기
+    const fetchBusinessInfo = async () => {
+      setLoading(true);
+      try {
+        // 여기서 외부 API 호출을 수행합니다
+        const response = await fetch(`https://api.example.com/business/${businessNumber}`);
+        const data = await response.json();
+        setBusinessInfo(data);
+      } catch (err) {
+        setError("Failed to fetch business information");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBusinessInfo();
+  }, [businessNumber]);
+
+  if (loading) {
+    return <CircularProgress />;
+  }
+
+  if (error) {
+    return <Typography color="error">{error}</Typography>;
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Business Information
+      </Typography>
+      {businessInfo ? (
+        <Box>
+          <Typography variant="body1">Company Name: {businessInfo.companyName}</Typography>
+          <Typography variant="body1">Address: {businessInfo.address}</Typography>
+          <Typography variant="body1">CEO: {businessInfo.ceo}</Typography>
+          <Button variant="contained" color="primary" onClick={onNext} sx={{ mt: 2 }}>
+            Confirm and Continue
+          </Button>
+        </Box>
+      ) : (
+        <Typography>No information available</Typography>
+      )}
+    </Box>
+  );
+};
+
+export default BusinessInfoVerification;

--- a/src/input/ProfileImageInput.tsx
+++ b/src/input/ProfileImageInput.tsx
@@ -1,18 +1,105 @@
-import React from 'react';
-import ShortTextInput from './ShortTextInput';
+import React, { useState } from 'react';
+import { Controller } from 'react-hook-form';
+import { TextField, Button, Box, Typography } from '@mui/material';
 
 interface ProfileImageInputProps {
   control: any;
-  onSubmit: () => void;
+  onNext: () => void;
 }
 
-const ProfileImageInput: React.FC<ProfileImageInputProps> = ({ control, onSubmit }) => {
+const defaultImages = [
+  "https://i.namu.wiki/i/v1b4uaM-yFnzNvFhk-Zge7CFxautpS8JCJdL16yN86DgHKLLkVLf1iUIhQkuj8qVc02jqurkgFzl6Id41N103x2z2DENixsN8pLYtRd4GJylg5g8aktlin_ye1X-CsYF8alXWZvpIGxfC-TlXnSRa_lvacJ2Y1Eugm7rJOeSd28.webp",
+  "https://i.namu.wiki/i/v1b4uaM-yFnzNvFhk-Zge83nkC_wnymdlUAPEJl56LmG0sptyzYvWKjSD9V1QScx7fMXMPWAvc9w5knbjdXWj1RXfXnOWxhhcfqxSMaglilFCJ4uXCu7jJgHSCsE46J5hyvW4RsjSbfm5PktIxHr2RrkGbCiVcmnl439nDAAf4c.webp",
+  "https://i.namu.wiki/i/v1b4uaM-yFnzNvFhk-Zgewjoy8VDTUsEm1dw5WQC8HrfEJcLi7y-FqtrSJ-rXDKubq3ewLo0MO7AxTzooJ1BMyxiwBCVZoEhwZbGHKMtOpVfggyGglKtuGVaU9Luwp890RDJE0v0YFvU32g5zbYnMZNi7B_AMwL6Rl_EkMb9M3c.webp",
+  "https://i.namu.wiki/i/v1b4uaM-yFnzNvFhk-Zge3-rrGrgydLxw509tVXb9O3dTpxosoDwoFc720uOiXklA3bqTmLIijXIhnuAqkf9x7lSy6fJvAbSRczCx7mx_pUdkbMTyyUXqw9cE-MuuXPJ2pGbCX2i-rI-wB-IFi-LBSAQJb9F-LKw2XF0MAIOVpA.webp"
+];
+
+const ProfileImageInput: React.FC<ProfileImageInputProps> = ({ control, onNext }) => {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const handleImageDrop = (event: React.DragEvent<HTMLDivElement>, onChange: (url: string) => void) => {
+    event.preventDefault();
+    const file = event.dataTransfer.files[0];
+    if (file && file.type.startsWith('image/')) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        onChange(result); // 이미지 URL을 폼에 설정
+        setPreviewUrl(result); // 미리보기를 위해 설정
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleDefaultImageClick = (url: string, onChange: (url: string) => void) => {
+    onChange(url);
+    setPreviewUrl(url);
+  };
+
   return (
-    <div>
-      <h3>Profile Picture</h3>
-      <ShortTextInput control={control} name="imageUrl" label="Image URL" />
-      <button type="submit" onClick={onSubmit}>Finish</button>
-    </div>
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Profile Picture
+      </Typography>
+      <Controller
+        name="imageUrl"
+        control={control}
+        defaultValue=""
+        render={({ field }) => (
+          <Box>
+            <TextField
+              {...field}
+              label="Image URL"
+              fullWidth
+              variant="outlined"
+              onChange={(e) => {
+                field.onChange(e.target.value);
+                setPreviewUrl(e.target.value);
+              }}
+              placeholder="Enter or drop an image URL here"
+            />
+            {/* 드래그 */}
+            <Box
+              onDrop={(event) => handleImageDrop(event, field.onChange)}
+              onDragOver={(event) => event.preventDefault()}
+              sx={{
+                border: '2px dashed #ccc',
+                padding: 2,
+                marginTop: 2,
+                textAlign: 'center',
+                borderRadius: 1,
+                color: '#777',
+                cursor: 'pointer'
+              }}
+            >
+              Drag and Drop Image Here
+            </Box>
+            {/* 미리보기 */}
+            {previewUrl && (
+              <Box sx={{ mt: 2, textAlign: 'center' }}>
+                <Typography variant="body2">Image Preview:</Typography>
+                <img src={previewUrl} alt="Preview" style={{ width: '150px', height: '150px', objectFit: 'cover', borderRadius: '8px' }} />
+              </Box>
+            )}
+            {/* 기본 제공 이미지 */}
+            <Box display="flex" justifyContent="space-around" mt={2}>
+              {defaultImages.map((url, index) => (
+                <img
+                  key={index}
+                  src={url}
+                  alt={`Default ${index + 1}`}
+                  onClick={() => handleDefaultImageClick(url, field.onChange)}
+                  style={{ width: '50px', height: '50px', cursor: 'pointer', borderRadius: '4px', border: previewUrl === url ? '2px solid #3f51b5' : '1px solid #ccc' }}
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+      />
+      <Button variant="contained" color="primary" onClick={onNext} sx={{ mt: 2 }}>
+        Finish
+      </Button>
+    </Box>
   );
 };
 

--- a/src/input/SchoolInput.tsx
+++ b/src/input/SchoolInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ShortTextInput from './ShortTextInput';
-import DateInput from './DateInput';
+import YearMonthInput from './YearMonthInput';
 import { Container, Typography, Button, Grid2 as Grid } from '@mui/material';
 
 interface SchoolInputProps {
@@ -39,14 +39,14 @@ const SchoolInput: React.FC<SchoolInputProps> = ({ control, index, onRemove }) =
         </Grid>
 
         <Grid size={{xs:12, sm:4}}>
-          <DateInput
+          <YearMonthInput
             control={control}
             name={`academicHistories[${index}].startDate`}
             label="Start Date"
           />
         </Grid>
         <Grid size={{xs:12, sm:4}}>
-          <DateInput
+          <YearMonthInput
             control={control}
             name={`academicHistories[${index}].endDate`}
             label="End Date"

--- a/src/input/StudentProfileSetup.tsx
+++ b/src/input/StudentProfileSetup.tsx
@@ -47,7 +47,7 @@ const StudentProfileSetup: React.FC = () => {
 
   const onNextStep = () => {
     if (userType === 'student') {
-      setStep('email');
+      setStep('basicInfo');
     } else if (userType === 'company') {
       setStep('businessNumber');
     } else if (userType === 'government') {
@@ -69,34 +69,34 @@ const StudentProfileSetup: React.FC = () => {
           <UserTypeInput control={control} onNext={onNextStep} />
         </Step>
 
-        {/* 학생 Step 2: Email 입력 */}
-        <Step name="email">
-          <EmailInput control={control} onNext={() => setStep('token')} />
-        </Step>
-
-        {/* 학생 3: Token 입력 */}
-        <Step name="token">
-          <TokenInput control={control} onNext={() => setStep('basicInfo')} />
-        </Step>
-
-        {/* 학생 4: Basic Info 입력 */}
+        {/* 학생 2: Basic Info 입력 */}
         <Step name="basicInfo">
           <BasicInfoInput control={control} onNext={() => setStep('academicHistory')} />
         </Step>
 
-        {/* 학생 5: Academic History 입력 */}
+        {/* 학생 3: Academic History 입력 */}
         <Step name="academicHistory">
           <AcademicHistoryInput control={control} onNext={() => setStep('languageProf')} />
         </Step>
 
-        {/* 학생 6: Language History 입력 */}
+        {/* 학생 4: Language History 입력 */}
         <Step name="languageProf">
           <LanguageProfInput control={control} onNext={() => setStep('imageUrl')} />
         </Step>
 
-        {/* 학생 7: Image URL 입력 */}
+        {/* 학생 5: Image URL 입력 */}
         <Step name="imageUrl">
-          <ProfileImageInput control={control} onSubmit={handleSubmit(onSubmit)} />
+          <ProfileImageInput control={control} onNext={() => setStep('email')} />
+        </Step>
+
+        {/* 학생 Step 6: Email 입력 */}
+        <Step name="email">
+          <EmailInput control={control} onNext={() => setStep('token')} />
+        </Step>
+
+        {/* 학생 7: Token 입력 */}
+        <Step name="token">
+          <TokenInput control={control} onSubmit={handleSubmit(onSubmit)} />
         </Step>
 
         {/* 기업 Step 2: Business Number 입력 */}
@@ -111,7 +111,7 @@ const StudentProfileSetup: React.FC = () => {
 
         {/* 기업 4: Token 입력 */}
         <Step name="businessToken">
-          <TokenInput control={control} onNext={() => setStep('imageUrl')} />
+          <TokenInput control={control} onSubmit={() => setStep('imageUrl')} />
         </Step>
 
         {/* 기관 Step 2: Government Number 입력 */}
@@ -126,7 +126,7 @@ const StudentProfileSetup: React.FC = () => {
 
         {/* 기관 4: Token 입력 */}
         <Step name="governmentToken">
-          <TokenInput control={control} onNext={() => setStep('imageUrl')} />
+          <TokenInput control={control} onSubmit={() => setStep('imageUrl')} />
         </Step>
       </Funnel>
     </form>

--- a/src/input/TokenInput.tsx
+++ b/src/input/TokenInput.tsx
@@ -3,15 +3,15 @@ import ShortTextInput from './ShortTextInput';
 
 interface TokenPageProps {
   control: any;
-  onNext: () => void;
+  onSubmit: () => void;
 }
 
-const TokenPage: React.FC<TokenPageProps> = ({ control, onNext }) => {
+const TokenPage: React.FC<TokenPageProps> = ({ control, onSubmit }) => {
   return (
     <div>
       <h3>Enter Verification Token</h3>
       <ShortTextInput control={control} name="token" label="Token" />
-      <button type="button" onClick={onNext}>Next</button>
+      <button type="submit" onClick={onSubmit}>Next</button>
     </div>
   );
 };

--- a/src/input/UserTypeInput.tsx
+++ b/src/input/UserTypeInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Controller } from 'react-hook-form';
-import { RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 interface UserTypeInputProps {
   control: any;
@@ -10,20 +10,63 @@ interface UserTypeInputProps {
 const UserTypeInput: React.FC<UserTypeInputProps> = ({ control, onNext }) => {
   return (
     <div>
-      <h3>Select User Type</h3>
+      <Typography variant="h5" gutterBottom>
+        Select User Type
+      </Typography>
       <Controller
         name="userType"
         control={control}
         defaultValue=""
         render={({ field }) => (
-          <RadioGroup {...field}>
-            <FormControlLabel value="student" control={<Radio />} label="학생" />
-            <FormControlLabel value="company" control={<Radio />} label="기업" />
-            <FormControlLabel value="government" control={<Radio />} label="국가기관" />
-          </RadioGroup>
+          <Box display="flex" gap={2}>
+            <Box
+              onClick={() => field.onChange('student')}
+              sx={{
+                padding: 2,
+                borderRadius: 1,
+                border: field.value === 'student' ? '2px solid #3f51b5' : '1px solid #ccc',
+                backgroundColor: field.value === 'student' ? '#e3f2fd' : '#f5f5f5',
+                cursor: 'pointer',
+                textAlign: 'center',
+                flex: 1
+              }}
+            >
+              <Typography>학생</Typography>
+            </Box>
+            <Box
+              onClick={() => field.onChange('company')}
+              sx={{
+                padding: 2,
+                borderRadius: 1,
+                border: field.value === 'company' ? '2px solid #3f51b5' : '1px solid #ccc',
+                backgroundColor: field.value === 'company' ? '#e3f2fd' : '#f5f5f5',
+                cursor: 'pointer',
+                textAlign: 'center',
+                flex: 1
+              }}
+            >
+              <Typography>기업</Typography>
+            </Box>
+            <Box
+              onClick={() => field.onChange('government')}
+              sx={{
+                padding: 2,
+                borderRadius: 1,
+                border: field.value === 'government' ? '2px solid #3f51b5' : '1px solid #ccc',
+                backgroundColor: field.value === 'government' ? '#e3f2fd' : '#f5f5f5',
+                cursor: 'pointer',
+                textAlign: 'center',
+                flex: 1
+              }}
+            >
+              <Typography>국가기관</Typography>
+            </Box>
+          </Box>
         )}
       />
-      <button type="button" onClick={onNext}>Next</button>
+      <button type="button" onClick={onNext} style={{ marginTop: '16px' }}>
+        Next
+      </button>
     </div>
   );
 };

--- a/src/input/YearMonthInput.tsx
+++ b/src/input/YearMonthInput.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Controller } from 'react-hook-form';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+
+interface DateInputProps {
+  control: any;
+  name: string;
+  label: string;
+}
+
+const DateInput: React.FC<DateInputProps> = ({ control, name, label }) => (
+  <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <DatePicker
+          {...field}
+          label={label}
+          views={['year', 'month']}
+          onChange={(date) => field.onChange(date)}
+          value={field.value}
+          slotProps={{
+            textField: { fullWidth: true },
+          }}
+        />
+      )}
+    />
+  </LocalizationProvider>
+);
+
+export default DateInput;


### PR DESCRIPTION
유저타입 radio에서 button으로 수정
휴대폰 번호 + 비상연락처 추가
입학 졸업 년월까지만 입력하도록 변경
이메일 step 가장 마지막으로 변경
프로필 이미지 드래그 앤 드롭 추가, 기본 이미지(임의) 4종류 추가

TODO: 국적, 사업자번호 입력 후 API 요청하여 사업자 정보 Display, 수정하도록 하기
질문: emailverificationtoken의 경우 몇글자인지?